### PR TITLE
feat!: add explicit conversion methods

### DIFF
--- a/src/main/java/com/github/legible/App.java
+++ b/src/main/java/com/github/legible/App.java
@@ -9,6 +9,6 @@ public class App {
   public static void main(String[] args) throws ONIXTagnameConverterException {
     ONIXTagnameConverter converter = new ONIXTagnameConverter();
     Source source = new StreamSource(System.in);
-    converter.convert(source, System.out);
+    converter.convertToShortTags(source, System.out);
   }
 }

--- a/src/main/java/com/github/legible/ONIXTagnameConverter.java
+++ b/src/main/java/com/github/legible/ONIXTagnameConverter.java
@@ -71,7 +71,7 @@ public class ONIXTagnameConverter {
     }
   }
 
-  public void transform(Source source, File outputFile) throws ONIXTagnameConverterException {
+  public void convert(Source source, File outputFile) throws ONIXTagnameConverterException {
     try {
       this.convert(source, this.processor.newSerializer(outputFile));
     } catch (SaxonApiException e) {

--- a/src/main/java/com/github/legible/ONIXTagnameConverter.java
+++ b/src/main/java/com/github/legible/ONIXTagnameConverter.java
@@ -49,34 +49,75 @@ public class ONIXTagnameConverter {
     }
   }
 
+  /**
+   * Convert converts the XML input according to the
+   * `convert.xsl` XSL stylesheet compiled in the
+   * constructor of this class.
+   * @param source Source of raw XML
+   * @param destination Destination where converted XML will be directed
+   * @throws SaxonApiException
+   */
   private void convert(Source source, Destination destination) throws SaxonApiException {
     this.onixTagnameConverter.setResultDocumentHandler(uri -> destination);
     this.onixTagnameConverter.setSource(source);
     this.onixTagnameConverter.transform();
   }
 
-  public void convert(Source source, OutputStream outputStream) throws ONIXTagnameConverterException {
+  /**
+   * convertToShortTags converts XML input to XML output with ONIX short tags.
+   * The output format of this conversion will be short tags regardless
+   * of the input format.
+   * @param source Source of raw XML
+   * @param destination Destination where converted XML will be directed
+   * @throws SaxonApiException
+   */
+  private void convertToShortTags(Source source, Destination destination) throws ONIXTagnameConverterException {
     try {
-      this.convert(source, this.processor.newSerializer(outputStream));
+      this.onixTagnameConverter.setParameter(new QName("output-format"), new XdmAtomicValue("short"));
+      this.convert(source, destination);
     } catch (SaxonApiException e) {
       throw new ONIXTagnameConverterException(e);
     }
   }
 
-  public void convert(Source source, Writer outputWriter) throws ONIXTagnameConverterException {
+  public void convertToShortTags(Source source, OutputStream outputStream) throws ONIXTagnameConverterException {
+    this.convertToShortTags(source, this.processor.newSerializer(outputStream));
+  }
+
+  public void convertToShortTags(Source source, Writer outputWriter) throws ONIXTagnameConverterException {
+    this.convertToShortTags(source, this.processor.newSerializer(outputWriter));
+  }
+
+  public void convertToShortTags(Source source, File outputFile) throws ONIXTagnameConverterException {
+    this.convertToShortTags(source, this.processor.newSerializer(outputFile));
+  }
+
+  /**
+   * convertToReferenceTags converts XML input to XML output with ONIX reference tags.
+   * The output format of this conversion will be reference tags regardless
+   * of the input format.
+   * @param source Source of raw XML
+   * @param destination Destination where converted XML will be directed
+   * @throws SaxonApiException
+   */
+  private void convertToReferenceTags(Source source, Destination destination) throws ONIXTagnameConverterException {
     try {
-      this.convert(source, this.processor.newSerializer(outputWriter));
+      this.onixTagnameConverter.setParameter(new QName("output-format"), new XdmAtomicValue("reference"));
+      this.convert(source, destination);
     } catch (SaxonApiException e) {
       throw new ONIXTagnameConverterException(e);
     }
   }
 
-  public void convert(Source source, File outputFile) throws ONIXTagnameConverterException {
-    try {
-      this.convert(source, this.processor.newSerializer(outputFile));
-    } catch (SaxonApiException e) {
-      throw new ONIXTagnameConverterException(e);
-    }
+  public void convertToReferenceTags(Source source, OutputStream outputStream) throws ONIXTagnameConverterException {
+    this.convertToReferenceTags(source, this.processor.newSerializer(outputStream));
   }
 
+  public void convertToReferenceTags(Source source, Writer outputWriter) throws ONIXTagnameConverterException {
+    this.convertToReferenceTags(source, this.processor.newSerializer(outputWriter));
+  }
+
+  public void convertToReferenceTags(Source source, File outputFile) throws ONIXTagnameConverterException {
+    this.convertToReferenceTags(source, this.processor.newSerializer(outputFile));
+  }
 }

--- a/src/main/resources/convert.xsl
+++ b/src/main/resources/convert.xsl
@@ -7,10 +7,13 @@
 <xsl:stylesheet version="2.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:fn="http://ns.editeur.org/">
   <xsl:param name="input-path" select="'schemas'" />
   <xsl:param name="result-document" select="'dummy.xml'" />
+<!--  output-format determines whether the result format will be ONIX short tags or reference tags.-->
+<!--  This stylesheet checks for `short` to convert to short tags, otherwise, it converts to reference tags.-->
+  <xsl:param name="output-format" required="yes" />
   <xsl:param name="dtd-path" select="''" />
   <xsl:variable name="new-namespace">
     <xsl:choose>
-      <xsl:when test="local-name(/*)='ONIXMessage'">
+      <xsl:when test="$output-format='short'">
         <xsl:value-of select="replace(namespace-uri(/*),'/reference','/short')" />
       </xsl:when>
       <xsl:otherwise>
@@ -44,7 +47,7 @@
   <xsl:variable name="target">
     <xsl:choose>
       <!-- v1.1 was xsl:when test="/ONIXMessage">short</xsl:when -->
-      <xsl:when test="local-name(/*)='ONIXMessage'">short</xsl:when>
+      <xsl:when test="$output-format='short'">short</xsl:when>
       <xsl:otherwise>reference</xsl:otherwise>
     </xsl:choose>
   </xsl:variable>

--- a/src/test/java/com/github/legible/ONIXTagnameConverterTest.java
+++ b/src/test/java/com/github/legible/ONIXTagnameConverterTest.java
@@ -29,7 +29,7 @@ public class ONIXTagnameConverterTest {
 
     Source source = new StreamSource(referenceNamesSample);
     StringWriter writer = new StringWriter();
-    tagTransformer.convert(source, writer);
+    tagTransformer.convertToShortTags(source, writer);
 
     String actual = writer.toString();
     String expected = new BufferedReader(new InputStreamReader(shortTagsSample, StandardCharsets.UTF_8)).lines()
@@ -48,11 +48,47 @@ public class ONIXTagnameConverterTest {
 
     Source source = new StreamSource(shortTagsSample);
     StringWriter writer = new StringWriter();
-    tagTransformer.convert(source, writer);
+    tagTransformer.convertToReferenceTags(source, writer);
 
     String actual = writer.toString();
     String expected = new BufferedReader(new InputStreamReader(referenceNamesSample, StandardCharsets.UTF_8)).lines()
         .collect(Collectors.joining("\n"));
+
+    assertThat(actual, isIdenticalTo(expected).ignoreWhitespace());
+  }
+
+  @Test
+  public void shouldKeepReferenceTagsIfOutputFormatIsReference() throws ONIXTagnameConverterException {
+    InputStream referenceTagsSample = getClass().getClassLoader().getResourceAsStream("Onix3sample_refnames.xml");
+    InputStream referenceTagsSampleDuplicate = getClass().getClassLoader().getResourceAsStream("Onix3sample_refnames.xml");
+
+    ONIXTagnameConverter tagTransformer = new ONIXTagnameConverter();
+
+    Source source = new StreamSource(referenceTagsSample);
+    StringWriter writer = new StringWriter();
+    tagTransformer.convertToReferenceTags(source, writer);
+
+    String actual = writer.toString();
+    String expected = new BufferedReader(new InputStreamReader(referenceTagsSampleDuplicate, StandardCharsets.UTF_8)).lines()
+      .collect(Collectors.joining("\n"));
+
+    assertThat(actual, isIdenticalTo(expected).ignoreWhitespace());
+  }
+
+  @Test
+  public void shouldKeepShortTagsIfOutputFormatIsShort() throws ONIXTagnameConverterException {
+    InputStream shortTagsSample = getClass().getClassLoader().getResourceAsStream("Onix3sample_shorttags.xml");
+    InputStream shortTagsSampleDuplicate = getClass().getClassLoader().getResourceAsStream("Onix3sample_shorttags.xml");
+
+    ONIXTagnameConverter tagTransformer = new ONIXTagnameConverter();
+
+    Source source = new StreamSource(shortTagsSample);
+    StringWriter writer = new StringWriter();
+    tagTransformer.convertToShortTags(source, writer);
+
+    String actual = writer.toString();
+    String expected = new BufferedReader(new InputStreamReader(shortTagsSampleDuplicate, StandardCharsets.UTF_8)).lines()
+      .collect(Collectors.joining("\n"));
 
     assertThat(actual, isIdenticalTo(expected).ignoreWhitespace());
   }


### PR DESCRIPTION
This adds explicit conversion methods, specifying the conversion format.
For example: 
- Given input with reference names, converting to short tags, you'd get short tags.
- Given input with short tags, converting to short tags, you'd still get short tags.
- (and so on)